### PR TITLE
Add managers and confirmedUsers structure in the serializer

### DIFF
--- a/app/src/serializers/team.serializer.js
+++ b/app/src/serializers/team.serializer.js
@@ -7,6 +7,12 @@ var teamSerializer = new JSONAPISerializer('team', {
     attributes: [
         'name', 'managers', 'users', 'areas', 'layers', 'confirmedUsers', 'createdAt'
     ],
+    managers: {
+      attributes: ['email', 'id']
+    },
+    confirmedUsers: {
+      attributes: ['email', 'id']
+    },
     keyForAttribute: 'camelCase'
 });
 


### PR DESCRIPTION
The serializer was failing because the structure of the objects was not specified